### PR TITLE
feat: add partition() utility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -275,6 +275,22 @@ export function any<T, E>(
   return results[results.length - 1];
 }
 
+/**
+ * Split an array of Results into separate arrays of Ok values and Err values.
+ * Useful for batch operations where you want to process successes and report failures separately.
+ */
+export function partition<T, E>(
+  results: readonly Result<T, E>[],
+): [T[], E[]] {
+  const oks: T[] = [];
+  const errs: E[] = [];
+  for (const r of results) {
+    if (r.ok) oks.push(r.value);
+    else errs.push(r.error);
+  }
+  return [oks, errs];
+}
+
 // -- fromNullable / fromPromise ----
 
 /**

--- a/tests/result.test.ts
+++ b/tests/result.test.ts
@@ -7,6 +7,7 @@ import {
   all,
   allTuple,
   any,
+  partition,
   fromNullable,
   fromPromise,
 } from "../src/index";
@@ -270,6 +271,38 @@ describe("any", () => {
   test("returns Err for empty array", () => {
     const r = any([]);
     expect(r.ok).toBe(false);
+  });
+});
+
+describe("partition", () => {
+  test("splits mixed Results into successes and failures", () => {
+    const [successes, failures] = partition([ok(1), err("a"), ok(2), err("b")]);
+    expect(successes).toEqual([1, 2]);
+    expect(failures).toEqual(["a", "b"]);
+  });
+
+  test("returns all values when all Ok", () => {
+    const [successes, failures] = partition([ok(1), ok(2), ok(3)]);
+    expect(successes).toEqual([1, 2, 3]);
+    expect(failures).toEqual([]);
+  });
+
+  test("returns all errors when all Err", () => {
+    const [successes, failures] = partition([err("a"), err("b"), err("c")]);
+    expect(successes).toEqual([]);
+    expect(failures).toEqual(["a", "b", "c"]);
+  });
+
+  test("handles empty array", () => {
+    const [successes, failures] = partition([]);
+    expect(successes).toEqual([]);
+    expect(failures).toEqual([]);
+  });
+
+  test("preserves order", () => {
+    const [successes, failures] = partition([ok(3), err("x"), ok(1), err("y"), ok(2)]);
+    expect(successes).toEqual([3, 1, 2]);
+    expect(failures).toEqual(["x", "y"]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `partition()` function that splits an array of `Result<T, E>` into `[T[], E[]]` — separate arrays of unwrapped Ok values and Err values
- Includes 5 tests covering mixed results, all-ok, all-err, empty array, and order preservation

Closes #4

## Test plan

- [x] All existing tests pass (`bun test` — 55 tests, 0 failures)
- [x] TypeScript build passes (`tsc`)
- [ ] Verify new `partition()` tests cover edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)